### PR TITLE
Add nix overlay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743568003,
-        "narHash": "sha256-ZID5T65E8ruHqWRcdvZLsczWDOAWIE7om+vQOREwiX0=",
+        "lastModified": 1759381078,
+        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b7ba7f9f45c5cd0d8625e9e217c28f8eb6a19a76",
+        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,14 +1,19 @@
 {
   description = "A flake for csharp-language-server";
 
-  inputs.flake-utils.url = "github:numtide/flake-utils";
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-        csharp-language-server = pkgs.rustPlatform.buildRustPackage {
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+    let
+      overlay = _: super: {
+        csharp-language-server = super.rustPlatform.buildRustPackage {
           checkFlags = [
             # Test is unable to persist files while testing in nix
             "--skip=first_line_is_jsonrpc"
@@ -19,20 +24,30 @@
 
           src = ./.;
 
-          cargoLock = {
-            lockFile = ./Cargo.lock;
-          };
+          cargoLock.lockFile = ./Cargo.lock;
 
-          nativeBuildInputs = [ pkgs.pkgs.dotnetCorePackages.dotnet_8.sdk ];
-
+          nativeBuildInputs = [ super.dotnetCorePackages.dotnet_8.sdk ];
+        };
+      };
+    in
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ overlay ];
         };
       in
       {
         devShell = pkgs.mkShell {
-          buildInputs = [ csharp-language-server ];
+          buildInputs = with pkgs; [ csharp-language-server ];
         };
 
-        packages.csharp-language-server = csharp-language-server;
+        packages = with pkgs; {
+          default = csharp-language-server;
+          inherit csharp-language-server;
+        };
       }
-    );
+    ) // {
+      overlays.default = overlay;
+    };
 }


### PR DESCRIPTION
This commit changes the flake to follow a few standards of formatting
but main actual additions are:
* New package output, default
* An overlay which people can use on pkgs to simply specify `pkgs.csharp-language-server`.